### PR TITLE
CTB-521 initial attempt at preventing close() from drying on flush failing

### DIFF
--- a/flume-ng-sinks/flume-hdfs-sink/src/main/java/org/apache/flume/sink/hdfs/BucketWriter.java
+++ b/flume-ng-sinks/flume-hdfs-sink/src/main/java/org/apache/flume/sink/hdfs/BucketWriter.java
@@ -404,9 +404,13 @@ class BucketWriter {
   public synchronized void close(boolean callCloseCallback)
     throws IOException, InterruptedException {
     checkAndThrowInterruptedException();
-    flush();
     boolean failedToClose = false;
     LOG.info("Closing {}", bucketPath);
+    try {
+      flush();
+    } catch (IOException e) {
+      LOG.warn("Unable to flush {}", bucketPath, e);
+    }
     CallRunner<Void> closeCallRunner = createCloseCallRunner();
     if (isOpen) {
       try {


### PR DESCRIPTION
in response to continued issues with hdfs connections